### PR TITLE
fix sort bug about MEDIAN [LOG2(TPM+1)]

### DIFF
--- a/pages/_organism/_project.vue
+++ b/pages/_organism/_project.vue
@@ -222,9 +222,10 @@
         this.filters = arr;
       },
       updateResultSort(sort) {
+        // NOTE: this code is left commented out as it may be needed
         // reset selectedItem if sort other then median is changed
-        if (sort.key !== 'LogMedian')
-          this.selectedId = this.mainItem[this.sampleIdKey];
+        // if (sort.key !== 'LogMedian')
+        //   this.selectedId = this.mainItem[this.sampleIdKey];
         this.resultsSort = sort;
       },
       updateSelectedItem({ id, sortOrder = 'down' }) {


### PR DESCRIPTION
@penqe 
お疲れ様です。お手すきにご確認ください。

サンプルアノテーションでソートしたあと、発現量でのソートに戻そうとして MEDIAN [LOG2(TPM+1)] の▲▼をクリックしても降順にならないバグを修正しました。