### PR TITLE
Disappearing gene filter after browser "previous" button

### DIFF
--- a/components/search/FilterNavigation.vue
+++ b/components/search/FilterNavigation.vue
@@ -27,6 +27,9 @@
         return this.$store.state.active_filter;
       },
     },
+    beforeCreate() {
+      this.$store.commit('set_active_filter', 'gene');
+    },
   };
 </script>
 <style lang="sass" scoped>


### PR DESCRIPTION
Set `active_filter` to 'gene' before `FilterNavigation.vue` create.
Not 100% sure if this is the most appropriate element to be added but it works.