### PR TITLE
remove duplicate in filter suggestions (gtex)

### DIFF
--- a/components/ScreenerView/ScreenerViewGeneFilter.vue
+++ b/components/ScreenerView/ScreenerViewGeneFilter.vue
@@ -173,11 +173,11 @@
 </template>
 
 <script>
-  import { mapGetters } from 'vuex';
-  import VueSimpleSuggest from 'vue-simple-suggest';
-  import WarningMessage from '../WarningMessage.vue';
   import 'floating-vue/dist/style.css';
   import _ from 'lodash';
+  import VueSimpleSuggest from 'vue-simple-suggest';
+  import { mapGetters } from 'vuex';
+  import WarningMessage from '../WarningMessage.vue';
 
   export default {
     components: {
@@ -346,10 +346,15 @@
               )
             );
           } catch (error) {
-            const defaultList = JSON.parse(
+            const rawDefaultList = JSON.parse(
               JSON.stringify(this.datasetSamples.byDefault[activeDateset])
             );
-            return defaultList;
+            const removeDuplicatesFromArray = list => {
+              return Array.from(new Set(list.map(JSON.stringify))).map(
+                JSON.parse
+              );
+            };
+            return removeDuplicatesFromArray(rawDefaultList);
           }
         };
         const sortSamplesByDescription = (a, b) =>

--- a/components/ScreenerView/ScreenerViewGeneFilter.vue
+++ b/components/ScreenerView/ScreenerViewGeneFilter.vue
@@ -349,12 +349,7 @@
             const rawDefaultList = JSON.parse(
               JSON.stringify(this.datasetSamples.byDefault[activeDateset])
             );
-            const removeDuplicatesFromArray = list => {
-              return Array.from(new Set(list.map(JSON.stringify))).map(
-                JSON.parse
-              );
-            };
-            return removeDuplicatesFromArray(rawDefaultList);
+            return _.uniqWith(rawDefaultList, _.isEqual);
           }
         };
         const sortSamplesByDescription = (a, b) =>


### PR DESCRIPTION
Under GTEx dataset, the specificity samples had duplicate objects in json.
This branch removes duplicates in sample suggestion list.