### PR TITLE
disable focus input field after mounted

### DIFF
--- a/components/search/SearchBar.vue
+++ b/components/search/SearchBar.vue
@@ -266,12 +266,6 @@
       if (this.filterType === 'gene' && this.searchConditions.gene.summary) {
         this.isSummaryIncluded = this.searchConditions[this.filterType].summary;
       }
-      setTimeout(() => {
-        const mainInputField = this.$refs.searchInput.inputElement;
-        if (!Boolean(mainInputField.value)) {
-          mainInputField.focus(), 10;
-        }
-      });
     },
     methods: {
       ...mapMutations({


### PR DESCRIPTION
I think now it's better to disable it.
After last time the extra search function added in the popup, the suggestion window will show every time after reload.